### PR TITLE
feat: create transpile-only version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Node JS loader for Typescript that supports tsconfig paths",
   "main": "index.js",
   "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./transpile-only": "./transpile-only.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/transpile-only.js
+++ b/transpile-only.js
@@ -1,0 +1,15 @@
+import { resolve as resolveTs } from 'ts-node/esm/transpile-only'
+import * as tsConfigPaths from 'tsconfig-paths'
+import { pathToFileURL } from 'url'
+
+const { absoluteBaseUrl, paths } = tsConfigPaths.loadConfig()
+const matchPath = tsConfigPaths.createMatchPath(absoluteBaseUrl, paths)
+
+export function resolve(specifier, ctx, defaultResolve) {
+  const match = matchPath(specifier)
+  return match
+    ? resolveTs(pathToFileURL(`${match}`).href, ctx, defaultResolve)
+    : resolveTs(specifier, ctx, defaultResolve)
+}
+
+export { getFormat, load, transformSource } from 'ts-node/esm/transpile-only'


### PR DESCRIPTION
fix #1

A simple copy paste of the index file, replacing `ts-node/esm` with `ts-node/esm/transpile-only`.
I didn't bother refactoring out the common code between the two files due to the files being so small but that probably should be done. Let me know if you want me to do this.