### PR TITLE
fix: use relative paths including extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { resolve as resolveTs } from 'ts-node/esm'
-import { resolverFactory } from './resolverFactory'
+import { resolverFactory } from './resolverFactory.js'
 
 export const resolve = resolverFactory(resolveTs)
 

--- a/resolverFactory.js
+++ b/resolverFactory.js
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'url'
 
-import { matchPath } from './matchPath'
+import { matchPath } from './matchPath.js'
 
 export const resolverFactory = (resolveTs) => {
     return function (specifier, ctx, defaultResolve) {

--- a/transpile-only.js
+++ b/transpile-only.js
@@ -1,5 +1,5 @@
 import { resolve as resolveTs } from 'ts-node/esm/transpile-only'
-import { resolverFactory } from './resolverFactory'
+import { resolverFactory } from './resolverFactory.js'
 
 export const resolve = resolverFactory(resolveTs)
 


### PR DESCRIPTION
This will allow for the loader to be used without the `--experimental-specifier-resolution=node` flag (for those that want that).