### PR TITLE
Allow v4 of `tsconfig-paths` as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ts-paths-esm-loader",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-paths-esm-loader",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "peerDependencies": {
         "ts-node": "^10.4.0",
-        "tsconfig-paths": "^3.12.0"
+        "tsconfig-paths": "^4.0.0 || ^3.12.0"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-paths-esm-loader",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Node JS loader for Typescript that supports tsconfig paths",
   "main": "index.js",
   "type": "module",
@@ -23,6 +23,6 @@
   "homepage": "https://github.com/luanglopes/ts-paths-esm-loader#readme",
   "peerDependencies": {
     "ts-node": "^10.4.0",
-    "tsconfig-paths": "^3.12.0"
+    "tsconfig-paths": "^4.0.0 || ^3.12.0"
   }
 }


### PR DESCRIPTION
I tested ts-paths-esm-loader with tsconfig-paths v4 in my project and it worked.

You can see [here](https://github.com/dividab/tsconfig-paths/blob/master/CHANGELOG.md#400---2022-05-02) that there were no relevant breaking changes in version 4 of tsconfig-paths.

I went ahead and bumped the version number of ts-paths-esm-loader.

Thanks for this project!